### PR TITLE
patches for Safari

### DIFF
--- a/styles/pages/partners/partners.css
+++ b/styles/pages/partners/partners.css
@@ -100,9 +100,11 @@
     aspect-ratio: 1/1;
 }
 
-.partner-card:hover {
-    transform: translateY(-4px);
-    box-shadow: var(--shadow-md);
+@media (hover: hover) {
+	.partner-card:hover {
+		transform: translateY(-4px);
+		box-shadow: var(--shadow-md);
+	}
 }
 
 .partner-card__image {
@@ -191,8 +193,10 @@
     text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
 }
 
-.partner-card:hover .partner-card__image::before {
-    opacity: 1;
+@media (hover: hover) {
+	.partner-card:hover .partner-card__image::before {
+		opacity: 1;
+	}
 }
 
 .partner-card__content {

--- a/styles/pages/partners/partners.css
+++ b/styles/pages/partners/partners.css
@@ -50,7 +50,7 @@
 .partners__grid--platinum {
     grid-template-columns: repeat(3, minmax(0, 1fr));
     max-width: 800px;
-    justify-items: center;
+    /* justify-items: center; */
 }
 
 .partners__grid--gold {


### PR DESCRIPTION
(not sure if anyone is aware of the bugs on Safari, but here is the fix)

## fix: platinum sponsors not showing on Safari

Screenshot of bug:
<img width="1436" alt="Screenshot 2024-11-26 at 7 43 23 PM" src="https://github.com/user-attachments/assets/c085232a-23da-45df-a0dc-0feda690027e">

## fix: hover status retains on iOS Safari
Disables hover effects on mobile (including Android).

Screenshot of bug:
<img width="393" alt="screenshot" src="https://github.com/user-attachments/assets/ec88a2ed-1ed6-4123-a52e-185cb6ab360d">
(The overlay won't disappear until the sponsor link loses focus)

## Tested Platforms
- [ ] Windows
- [x] macOS (Safari, Chrome, Firefox)
- [x] iOS
- [ ] Android